### PR TITLE
Add Sail CI info to Continuous Integration page

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -26,3 +26,17 @@ install:
   - curl -L https://unpkg.com/@pnpm/self-installer | node
   - pnpm install
 ```
+
+## Sail CI
+
+On [Sail CI](https://sail.ci/), you can use pnpm for installing your dependencies by adding this to your `.sail.yml` file:
+
+```yaml
+install:
+  image: znck/docker-pnpm:10
+  command:
+    - pnpm
+  args:
+    - install
+```
+To get the exact Node version and pnpm version you require you can always make your own Docker image and push to [Docker Hub](https://hub.docker.com/).


### PR DESCRIPTION
Hi, just thought I would add instructions on how to use pnpm on [Sail CI](https://sail.ci/).

Also, have you thought about maintaining an official Docker image for pnpm that you automatically update with each release? I found [znck/docker-pnpm](https://hub.docker.com/r/znck/docker-pnpm/) which was quite comprehensive but it stopped getting updated about 5 months ago.