### PR TITLE
only-allow-pnpm: fix and use npx

### DIFF
--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -9,7 +9,7 @@ To prevent devs from using other package managers, add the following `preinstall
 ```json
 {
   "scripts": {
-    "preinstall": "node --eval \"!process.env.npm_config_user_agent.startsWith('pnpm/')&&(console.log('Use `pnpm install` to install dependencies in this repository')||true)&&process.exit(1)\""
+    "preinstall": "node -e '!process.env.npm_config_user_agent.startsWith(\"pnpm/\")&&!console.log(\"Use `npx pnpm install` to install dependencies in this repository\\n\")&&process.exit(1)'"
   }
 }
 ```


### PR DESCRIPTION
The shortening is just for cuteness, but providing the user with the `npx` command makes it always work.

Furthermore, the backticks were being evaluated, using single quotes makes bash ignore them. Now the command works.