### PR TITLE
Fix only-allow-pnpm example

### DIFF
--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -9,7 +9,7 @@ To prevent devs from using other package managers, add the following `preinstall
 ```json
 {
   "scripts": {
-    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/') && !console.log('Use \\`npx pnpm install\\` to install dependencies in this repository\\n')&&process.exit(1)\""
+    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/') && !console.log('Use \\`npx pnpm install\\` to install dependencies in this repository\\n') && process.exit(1)\""
   }
 }
 ```

--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -9,7 +9,7 @@ To prevent devs from using other package managers, add the following `preinstall
 ```json
 {
   "scripts": {
-    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/')&&!console.log('Use `npx pnpm install` to install dependencies in this repository\\n')&&process.exit(1)\""
+    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/')&&!console.log('Use npx pnpm install to install dependencies in this repository\\n')&&process.exit(1)\""
   }
 }
 ```

--- a/docs/only-allow-pnpm.md
+++ b/docs/only-allow-pnpm.md
@@ -9,7 +9,7 @@ To prevent devs from using other package managers, add the following `preinstall
 ```json
 {
   "scripts": {
-    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/')&&!console.log('Use npx pnpm install to install dependencies in this repository\\n')&&process.exit(1)\""
+    "preinstall": "node -e \"!process.env.npm_config_user_agent.startsWith('pnpm/') && !console.log('Use \\`npx pnpm install\\` to install dependencies in this repository\\n')&&process.exit(1)\""
   }
 }
 ```


### PR DESCRIPTION
It looks like the "`" back tick makes yarn and pnpm hang.

Removing them make yarn console the message and pnpm works like expected!