### PR TITLE
Fix typo in update.md

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -7,7 +7,7 @@ Aliases: `up`
 
 `pnpm update` updates packages to their latest version based on the specified range.
 
-When used without arguments, updates all dopependencies.
+When used without arguments, updates all dependencies.
 You can use patterns to update all dependencies that match it.
 
 ## Synopsis


### PR DESCRIPTION
Changes "dopependencies" to "dependencies" in [`docs/cli/update.md`](https://github.com/pnpm/pnpm.github.io/blob/976cc8aa144bd208d8eb54e9dbf9f141bd0847e3/docs/cli/update.md). That's it.

It was a pretty dope typo though, haven't seen many like it. :)