### PR TITLE
fix typo: replace 'comletion' with 'completion'

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -570,7 +570,7 @@
         "title": "pnpm update"
       },
       "version-4.9/version-4.9-completion": {
-        "title": "Command line tab-comletion"
+        "title": "Command line tab-completion"
       }
     },
     "links": {

--- a/website/versioned_docs/version-4.9/completion.md
+++ b/website/versioned_docs/version-4.9/completion.md
@@ -1,6 +1,6 @@
 ---
 id: version-4.9-completion
-title: Command line tab-comletion
+title: Command line tab-completion
 original_id: completion
 ---
 


### PR DESCRIPTION
Small typo in the docs, **Command line tab-comletion** should be **Command line tab-completion**