### PR TITLE
Package store documentation out of sync

### DIFF
--- a/docs/about-the-package-store.md
+++ b/docs/about-the-package-store.md
@@ -38,13 +38,13 @@ A file in the root of store that contains information about projects depending o
 
 ```json
 {
-  "/home/john_smith/src/ied": [
-    "registry.npmjs.org/npm/3.10.2"
+  "registry.npmjs.org/npm/3.10.2": [
+    "/home/john_smith/src/ied"
   ],
-  "/home/john_smith/src/ied": [
-    "registry.npmjs.org/arr-flatten/1.0.1",
-    "registry.npmjs.org/byline/5.0.0",
-    "registry.npmjs.org/cache-manager/2.2.0"
+  "registry.npmjs.org/arr-flatten/1.0.1": [
+    "/home/john_smith/src/ied",
+    "/home/john_smith/src/new_project",
+    "/home/betsy_smith/src/abc",
   ]
 }
 ```


### PR DESCRIPTION
I believe after inspecting both the file generated, and the source here: https://github.com/pnpm/pnpm/blob/v4.14.3/packages/types/src/store.ts

It seems the store json is actually the inverse of what's documented