### PR TITLE
Fix broken link to about package store

### DIFF
--- a/docs/cli/store.md
+++ b/docs/cli/store.md
@@ -3,7 +3,7 @@ id: store
 title: pnpm store
 ---
 
-Managing the [package store](../about-the-package-store).
+Managing the [package store](../about-package-store).
 
 ## Commands
 

--- a/website/versioned_docs/version-3.8/cli/store.md
+++ b/website/versioned_docs/version-3.8/cli/store.md
@@ -4,7 +4,7 @@ title: pnpm store
 original_id: store
 ---
 
-Managing the [package store](../about-the-package-store).
+Managing the [package store](../about-package-store).
 
 ## Commands
 
@@ -26,7 +26,7 @@ Added in: v2.12.0
 pnpm store add &lt;pkg>...
 ```
 
-Adds new packages to the pnpm store directly. 
+Adds new packages to the pnpm store directly.
 Does not modify any projects or files outside the store.
 
 Usage examples:

--- a/website/versioned_docs/version-4.0/cli/store.md
+++ b/website/versioned_docs/version-4.0/cli/store.md
@@ -4,7 +4,7 @@ title: pnpm store
 original_id: store
 ---
 
-Managing the [package store](../about-the-package-store).
+Managing the [package store](../about-package-store).
 
 ## Commands
 
@@ -26,7 +26,7 @@ Added in: v2.12.0
 pnpm store add &lt;pkg>...
 ```
 
-Adds new packages to the pnpm store directly. 
+Adds new packages to the pnpm store directly.
 Does not modify any projects or files outside the store.
 
 Usage examples:

--- a/website/versioned_docs/version-5.0/cli/store.md
+++ b/website/versioned_docs/version-5.0/cli/store.md
@@ -4,7 +4,7 @@ title: pnpm store
 original_id: store
 ---
 
-Managing the [package store](../about-the-package-store).
+Managing the [package store](../about-package-store).
 
 ## Commands
 
@@ -26,7 +26,7 @@ Added in: v2.12.0
 pnpm store add &lt;pkg>...
 ```
 
-Adds new packages to the pnpm store directly. 
+Adds new packages to the pnpm store directly.
 Does not modify any projects or files outside the store.
 
 Usage examples:


### PR DESCRIPTION
Docusaurus uses `id` in metadata to link docs, not file name.

> New markdown files within docs will show up as pages on the website. Links to those documents are created first by using the id in the header of each document. If there is no id field, then the name of the file will serve as the link name.
>
> https://docusaurus.io/docs/en/navigation#how-documents-are-linked

And `about-the-package-store.md` has an `id` not matching its file name:

https://github.com/pnpm/pnpm.github.io/blob/source/docs/about-the-package-store.md#L2

![image](https://user-images.githubusercontent.com/1330321/84463694-1d565580-aca5-11ea-978c-e4b409f8d62f.png)

Looks like this link was broken since it exists.