### PR TITLE
Put actually working docker image in docs

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -62,7 +62,7 @@ On [Sail CI](https://sail.ci/), you can use pnpm for installing your dependencie
 
 ```yaml
 install:
-  image: znck/docker-pnpm:10
+  image: znck/pnpm:latest
   command:
     - pnpm
   args:

--- a/website/versioned_docs/version-2/continuous-integration.md
+++ b/website/versioned_docs/version-2/continuous-integration.md
@@ -58,7 +58,7 @@ On [Sail CI](https://sail.ci/), you can use pnpm for installing your dependencie
 
 ```yaml
 install:
-  image: znck/docker-pnpm:10
+  image: znck/pnpm:latest
   command:
     - pnpm
   args:

--- a/website/versioned_docs/version-3.7/continuous-integration.md
+++ b/website/versioned_docs/version-3.7/continuous-integration.md
@@ -60,7 +60,7 @@ On [Sail CI](https://sail.ci/), you can use pnpm for installing your dependencie
 
 ```yaml
 install:
-  image: znck/docker-pnpm:10
+  image: znck/pnpm:latest
   command:
     - pnpm
   args:

--- a/website/versioned_docs/version-4.12/continuous-integration.md
+++ b/website/versioned_docs/version-4.12/continuous-integration.md
@@ -63,7 +63,7 @@ On [Sail CI](https://sail.ci/), you can use pnpm for installing your dependencie
 
 ```yaml
 install:
-  image: znck/docker-pnpm:10
+  image: znck/pnpm:latest
   command:
     - pnpm
   args:


### PR DESCRIPTION
Note - it is 6 month old version of pnpm, and seems entirely unofficial and with just 1 build in february.

Probably shouldn't be even mentioned in the docs?