### PR TITLE
Fix description of which package versions are bumped

### DIFF
--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -25,7 +25,7 @@ To generate a new changeset, run `pnpx changeset` in the root of the repository.
 
 ## Releasing changes
 
-1. Run `pnpx changeset version`. This will bump the versions of the packages previously specified with `pnpx changeset` and update the changelog files.
+1. Run `pnpx changeset version`. This will bump the versions of the packages previously specified with `pnpx changeset` (and any dependents of those) and update the changelog files.
 1. Run `pnpm install`. This will update the lockfile.
 1. Commit the changes.
 1. Run `pnpm publish -r`. This command will publish all packages that have bumped versions not yet present in the registry.

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -25,7 +25,7 @@ To generate a new changeset, run `pnpx changeset` in the root of the repository.
 
 ## Releasing changes
 
-1. Run `pnpx changeset version`. This will bump all the package versions in the monorepo and update the changelog files.
+1. Run `pnpx changeset version`. This will bump the versions of the packages previously specified with `pnpx changeset` and update the changelog files.
 1. Run `pnpm install`. This will update the lockfile.
 1. Commit the changes.
 1. Run `pnpm publish -r`. This command will publish all packages that have bumped versions not yet present in the registry.


### PR DESCRIPTION
I'm not 100% sure my new text is correct, but I am sure the old text was not correct. `pnpm changeset version` doesn't bump **all** package versions. I had been scared to run it because I thought that's what it would do, but when I actually ran it then it only bumped versions for a couple of packages.