### PR TITLE
Set tagline as meta description for frontpage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -109,7 +109,7 @@ function Home() {
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description={siteConfig.tagline}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>


### PR DESCRIPTION
Adds a better meta description for shared links 

Old:
![image](https://user-images.githubusercontent.com/5442549/113058439-69c83e80-91ae-11eb-9e59-17f3751b43c2.png)
