### PR TITLE
Set --no-audit & --legacy-peer-deps in benchmarks for npm

### DIFF
--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -14,7 +14,6 @@ module.exports = {
       'cache',
       '--registry',
       'https://registry.npmjs.org/',
-      '--no-audit',
       '--legacy-peer-deps'
     ]
   },

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -13,7 +13,9 @@ module.exports = {
       '--cache',
       'cache',
       '--registry',
-      'https://registry.npmjs.org/'
+      'https://registry.npmjs.org/',
+      '--no-audit',
+      '--legacy-peer-deps'
     ]
   },
   pnpm: {


### PR DESCRIPTION
Setting these should more accurately compare performance as `yarn` & `pnpm` do not audit or install peer-deps by default.