### PR TITLE
Docs/add benchmarks datetime

### DIFF
--- a/benchmarks/generateSvg.js
+++ b/benchmarks/generateSvg.js
@@ -15,7 +15,7 @@ const NPM_COLOR = '#cd3731'
 const YARN_COLOR = '#248ebd'
 const PNPM_COLOR = '#fbae00'
 
-export default (resultArrays, pms, tests) => {
+export default (resultArrays, pms, tests, formattedNow) => {
   let svgStr = ''
   // colors taken from logos (where possible)
   const colors = [ NPM_COLOR, PNPM_COLOR, YARN_COLOR, YARN_COLOR ]
@@ -188,7 +188,7 @@ export default (resultArrays, pms, tests) => {
 
   // add node version
   ;(() => {
-    const text = `Tests were run using Node.js ${process.version}`
+    const text = `Tests were run using Node.js ${process.version} at: ${formattedNow}`
     const anchor = 'end'
     const x = graph.x + graph.w
     const y = vb.h - 2

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -109,6 +109,7 @@ async function run () {
   await fs.promises.mkdir(managersDir, { recursive: true })
   spawn.sync('pnpm', ['init', '--yes'], { cwd: managersDir })
   spawn.sync('pnpm', ['add', 'yarn@latest', 'npm@latest', 'pnpm@latest'], { cwd: managersDir, stdio: 'inherit' })
+  const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())
   const pms = [ 'npm', 'pnpm', 'yarn', 'yarn_pnp' ]
   const sections = []
   const svgs = []
@@ -153,6 +154,8 @@ async function run () {
 
   const introduction = stripIndents`
   # Benchmarks of JavaScript Package Managers
+
+  **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
   This benchmark compares the performance of npm, pnpm, and Yarn (both regular and PnP variant).
   `

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -145,7 +145,7 @@ async function run () {
 
     svgs.push({
       path: path.join(DIRNAME, '../static/img/benchmarks', `${fixture.name}.svg`),
-      file: generateSvg(resArray, [cmdsMap.npm, cmdsMap.pnpm, cmdsMap.yarn, cmdsMap.yarn_pnp], testDescriptions)
+      file: generateSvg(resArray, [cmdsMap.npm, cmdsMap.pnpm, cmdsMap.yarn, cmdsMap.yarn_pnp], testDescriptions, formattedNow)
     })
   }
 


### PR DESCRIPTION
This adds the timestamp of the benchmark result. When the GitHub action runs daily, it updates with the latest timestamp.

![out](https://user-images.githubusercontent.com/922234/118388090-e1660600-b654-11eb-8fef-b029df67aea8.jpg)
