### PR TITLE
Feat/add yarn berry to benchmark

### DIFF
--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -30,23 +30,18 @@ export default {
   },
   yarn: {
     scenario: 'yarn',
-    legend: 'Yarn',
+    legend: 'Yarn Berry',
     name: 'yarn',
     args: [
-      '--ignore-scripts',
-      '--cache-folder',
-      'cache'
+      'install'
     ]
   },
   yarn_pnp: {
     scenario: 'yarn_pnp',
-    legend: "Yarn PnP",
+    legend: 'Yarn Berry PnP',
     name: 'yarn',
     args: [
-      '--pnp',
-      '--ignore-scripts',
-      '--cache-folder',
-      'cache'
+      'install'
     ]
   }
 }

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,5 +1,7 @@
 'use strict'
 import fs from 'fs'
+import { promisify } from 'util'
+import rimraf from 'rimraf'
 import mkdirp from 'mkdirp'
 import commonTags from 'common-tags'
 import prettyMs from 'pretty-ms'
@@ -11,6 +13,8 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 
 const DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+const TMP = path.join(DIRNAME, '.tmp')
+
 const { stripIndents } = commonTags
 const LIMIT_RUNS = 3
 
@@ -106,7 +110,10 @@ run()
 
 async function run () {
   const managersDir = path.join(DIRNAME, 'managers')
-  await fs.promises.mkdir(managersDir, { recursive: true })
+  await Promise.allSettled([
+    promisify(rimraf)(TMP),
+    fs.promises.mkdir(managersDir, { recursive: true }),
+  ])
   spawn.sync('pnpm', ['init', '--yes'], { cwd: managersDir })
   spawn.sync('pnpm', ['add', 'yarn@latest', 'npm@latest', 'pnpm@latest'], { cwd: managersDir, stdio: 'inherit' })
   const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -104,6 +104,23 @@ const toArray = (pms, resultsObj) => {
     )
 }
 
+async function installYarnBerryLikeModule (managersDir) {
+  spawn.sync('pnpx', ['yarn', 'set', 'version', 'berry'], { cwd: managersDir, stdio: 'inherit' })
+  const result = spawn.sync('pnpx', ['yarn', '--version'], { cwd: managersDir })
+  const yarnBerryVersion = result.stdout.toString().trim()
+
+  const yarnPkgJsonPath = path.join(managersDir, 'node_modules/yarn/package.json')
+  const yarnPkgJson = JSON.parse(fs.readFileSync(yarnPkgJsonPath, 'utf-8'))
+  yarnPkgJson.version = yarnBerryVersion
+
+  // Replace yarn binary with the yarn berry script
+  await Promise.allSettled([
+    fs.promises.writeFile(yarnPkgJsonPath, JSON.stringify(yarnPkgJson)),
+    fs.promises.rename(path.join(DIRNAME, 'managers/.yarn/releases/yarn-berry.cjs'), path.join(DIRNAME, 'managers/node_modules/.bin/yarn')),
+    fs.promises.rm(path.join(DIRNAME, 'managers/.yarnrc.yml')),
+  ]);
+}
+
 run()
   .then(() => console.log('done'))
   .catch(err => console.error(err))
@@ -118,6 +135,7 @@ async function run () {
   ])
   spawn.sync('pnpm', ['init', '--yes'], { cwd: managersDir })
   spawn.sync('pnpm', ['add', 'yarn@latest', 'npm@latest', 'pnpm@latest'], { cwd: managersDir, stdio: 'inherit' })
+  await installYarnBerryLikeModule(managersDir)
   const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())
   const pms = [ 'npm', 'pnpm', 'yarn', 'yarn_pnp' ]
   const sections = []

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -155,8 +155,8 @@ async function run () {
     sections.push(stripIndents`
       ${fixture.mdDesc}
 
-      | action  | cache | lockfile | node_modules| npm | pnpm | Yarn | Yarn PnP |
-      | ---     | ---   | ---      | ---         | --- | --- | --- | --- |
+      | action  | cache | lockfile | node_modules| npm | pnpm | Yarn Berry | Yarn Berry PnP |
+      | ---     | ---   | ---      | ---         | --- | --- | --- | --- | --- |
       | install |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(yarnPnPRes.firstInstall)} |
       | install | ✔     | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | n/a |
       | install | ✔     | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnPnPRes.withWarmCacheAndLockfile)} |

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -10,7 +10,6 @@
         "get-folder-size": "^1.0.0",
         "load-json-file": "^6.2.0",
         "load-yaml-file": "^0.1.0",
-        "mkdirp": "^0.5.1",
         "path-key": "^2.0.1",
         "pretty-bytes": "^4.0.2",
         "pretty-ms": "^2.1.0",

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,8 +1,7 @@
 {
     "type": "module",
     "scripts": {
-        "prebench:clean": "./node_modules/.bin/rimraf .tmp",
-        "benchmark": "pnpm run prebench:clean && node ./index.js"
+        "benchmark": "node ./index.js"
     },
     "dependencies": {
         "common-tags": "^1.3.1",

--- a/benchmarks/pnpm-lock.yaml
+++ b/benchmarks/pnpm-lock.yaml
@@ -7,7 +7,6 @@ specifiers:
   get-folder-size: ^1.0.0
   load-json-file: ^6.2.0
   load-yaml-file: ^0.1.0
-  mkdirp: ^0.5.1
   path-key: ^2.0.1
   pretty-bytes: ^4.0.2
   pretty-ms: ^2.1.0
@@ -22,7 +21,6 @@ dependencies:
   get-folder-size: 1.0.1
   load-json-file: 6.2.0
   load-yaml-file: 0.1.1
-  mkdirp: 0.5.5
   path-key: 2.0.1
   pretty-bytes: 4.0.2
   pretty-ms: 2.1.0

--- a/src/.tmp/npm/alotta-files/package.json
+++ b/src/.tmp/npm/alotta-files/package.json
@@ -2,7 +2,6 @@
   "name": "alotta-modules",
   "version": "0.0.1",
   "dependencies": {
-    "animate.less": "^2.2.0",
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.4.0",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
## Description

This PR adds `yarn berry` into the benchmark. 

Previously, I mainly use `yarn berry` and I switched to `pnpm` recently which is really surprising. But I'm still curious about the performances differences though so here's the updated bench.

Feel free to modify anything!

## Prevent Global Cache

To get the correct bench result, one might want to remove global cache before running:

```
rm -rf ~/.pnpm-store
rm -rf ~/.yarn/berry
```

Note that after running the benchmark script, on my machine it will be:

```
> du -h -d=0 ~/.pnpm-store
34M	/Users/tomchentw/.pnpm-store
> du -h -d=0 ~/.yarn/berry
4.0K	/Users/tomchentw/.yarn/berry
```

Where the `34M` should be the dependencies for `npm`, `pnpm` and `yarn` during the initialization step.

## Screenshot

![JPEG-1](https://user-images.githubusercontent.com/922234/118393979-817f5780-b674-11eb-81cd-d85367cd6b99.jpg)
