### PR TITLE
Updates edit link to point to main branch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ function makeEditUrl (locale, path1, path2) {
     return `https://crowdin.com/project/pnpm/${LOCALE_FULL_CODE[locale] || locale}`;
   }
   // Link to Github for English docs
-  return `https://github.com/pnpm/pnpm.github.io/edit/source/${path1}/${path2}`;
+  return `https://github.com/pnpm/pnpm.github.io/edit/main/${path1}/${path2}`;
 }
 
 module.exports={


### PR DESCRIPTION
Currently the edit link points to a `source` branch which does not exist, resulting in anyone pressing the "edit this page" button hitting GitHub's 404.
This pr just changes the branch to `main` so you can edit the page