### PR TITLE
Fix/benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
       - run: curl -f https://get.pnpm.io/v6.js | node - add --global pnpm@next
       - run: pnpm --dir=benchmarks install
       - run: pnpm --dir=benchmarks run benchmark

--- a/versioned_docs/version-6.x/continuous-integration.md
+++ b/versioned_docs/version-6.x/continuous-integration.md
@@ -142,3 +142,26 @@ build:
     paths:
       - .pnpm-store
 ```
+
+## Bitbucket Pipelines
+
+You can use pnpm for installing and caching your dependencies:
+
+```yaml title=".bitbucket-pipelines.yml"
+definitions:
+  caches:
+    pnpm: $BITBUCKET_CLONE_DIR/.pnpm-store
+
+pipelines:
+  pull-requests:
+    "**":
+      - step:
+          name: Build and test
+          image: node:14.16.0
+          script:
+            - curl -f https://get.pnpm.io/v6.js | node - add --global pnpm@6
+            - pnpm install
+            - pnpm run build # Replace with your build/test…etc. commands
+          caches:
+            - pnpm
+```


### PR DESCRIPTION
## Issue
Debug why benchmarks are not reflected on the docs site.
![JPEG-1](https://user-images.githubusercontent.com/922234/119227897-d292be00-bb42-11eb-82bc-50f5ee03ac38.jpg)

## Solution
https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_rm_path_options_callback
fs.rm was added v14.14.0.
![JPEG-2](https://user-images.githubusercontent.com/922234/119227899-d6264500-bb42-11eb-8499-e1ef8a03cdc3.jpg)

Update the benchmark workflow to use node@16
