### PR TITLE
fix typo inside `add.md`: `Exempli gratia` -> `For example`

### DIFF
--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -77,7 +77,7 @@ pnpm add <git remote url>
 ```
 
 Installs the package from the hosted Git provider, cloning it with Git.
-You can use a protocol for certain Git providers. Exempli gratia,
+You can use a protocol for certain Git providers. For example,
 `pnpm add github:user/repo`
 
 You may install from Git by:

--- a/versioned_docs/version-4.x/cli/exec.md
+++ b/versioned_docs/version-4.x/cli/exec.md
@@ -17,6 +17,6 @@ Disregards concurrency and topological sorting configuration entirely and runs
 the command immediately in all matching packages, with prefixed streaming
 output.
 
-This is the preferred option for processes that take a long time to run, exempli
-gratia, running a build process with the watch flag over a large number of
+This is the preferred option for processes that take a long time to run.
+For example, running a build process with the watch flag over a large number of
 packages.

--- a/versioned_docs/version-5.x/cli/add.md
+++ b/versioned_docs/version-5.x/cli/add.md
@@ -77,7 +77,7 @@ pnpm add <git remote url>
 ```
 
 Installs the package from the hosted Git provider, cloning it with Git.
-You can use a protocol for certain Git providers. Exempli gratia,
+You can use a protocol for certain Git providers. For example,
 `pnpm add github:user/repo`
 
 You may install from Git by:

--- a/versioned_docs/version-5.x/cli/exec.md
+++ b/versioned_docs/version-5.x/cli/exec.md
@@ -17,6 +17,6 @@ Disregards concurrency and topological sorting configuration entirely and runs
 the command immediately in all matching packages, with prefixed streaming
 output.
 
-This is the preferred option for processes that take a long time to run, exempli
-gratia, running a build process with the watch flag over a large number of
+This is the preferred option for processes that take a long time to run.
+For example, running a build process with the watch flag over a large number of
 packages.

--- a/versioned_docs/version-6.x/cli/add.md
+++ b/versioned_docs/version-6.x/cli/add.md
@@ -77,7 +77,7 @@ pnpm add <git remote url>
 ```
 
 Installs the package from the hosted Git provider, cloning it with Git.
-You can use a protocol for certain Git providers. Exempli gratia,
+You can use a protocol for certain Git providers. For example,
 `pnpm add github:user/repo`
 
 You may install from Git by:

--- a/versioned_docs_archived/version-2.x/cli/add.md
+++ b/versioned_docs_archived/version-2.x/cli/add.md
@@ -77,7 +77,7 @@ pnpm add <git remote url>
 ```
 
 Installs the package from the hosted Git provider, cloning it with Git.
-You can use a protocol for certain Git providers. Exempli gratia,
+You can use a protocol for certain Git providers. For example,
 `pnpm add github:user/repo`
 
 You may install from Git by:

--- a/versioned_docs_archived/version-2.x/cli/exec.md
+++ b/versioned_docs_archived/version-2.x/cli/exec.md
@@ -17,6 +17,6 @@ Disregards concurrency and topological sorting configuration entirely and runs
 the command immediately in all matching packages, with prefixed streaming
 output.
 
-This is the preferred option for processes that take a long time to run, exempli
-gratia, running a build process with the watch flag over a large number of
+This is the preferred option for processes that take a long time to run.
+For example, running a build process with the watch flag over a large number of
 packages.

--- a/versioned_docs_archived/version-3.x/cli/exec.md
+++ b/versioned_docs_archived/version-3.x/cli/exec.md
@@ -17,6 +17,6 @@ Disregards concurrency and topological sorting configuration entirely and runs
 the command immediately in all matching packages, with prefixed streaming
 output.
 
-This is the preferred option for processes that take a long time to run, exempli
-gratia, running a build process with the watch flag over a large number of
+This is the preferred option for processes that take a long time to run.
+For example, running a build process with the watch flag over a large number of
 packages.


### PR DESCRIPTION
Related string/issue on Crowdin: https://crowdin.com/translate/pnpm/2976/en-ru#97282