### PR TITLE
Warn that prune is not monorepo-aware at this time

### DIFF
--- a/docs/cli/prune.md
+++ b/docs/cli/prune.md
@@ -14,3 +14,10 @@ Remove the packages specified in `devDependencies`.
 ### --no-optional
 
 Remove the packages specified in `optionalDependencies`.
+
+:::warning
+
+The prune command does not support recursive execution on a monorepo currently. To only install production-dependencies in a monorepo `node_modules` folders can be deleted and then re-installed with `pnpm install --prod`.
+
+:::
+


### PR DESCRIPTION
I wasted some time wondering why prune didn't work as expected, and it made sense once I discovered the command isn't monorepo-aware. I thought perhaps others would enjoy some notice on that. WDYT?