### PR TITLE
fix: Visually similar logo height for `/users`

### DIFF
--- a/users.json
+++ b/users.json
@@ -239,6 +239,6 @@
     "image": "/img/users/pabio.svg",
     "infoLink": "https://pabio.io",
     "pinned": false,
-    "width": 100
+    "width": 180
   }
 ]


### PR DESCRIPTION
This is a quick fix for #181 where I've resized the @pabio logo to be visually similar to the ones next to it.

Before:

<img width="1035" alt="Microsoft Edge screenshot 2021-12-08 VS5G20Gf" src="https://user-images.githubusercontent.com/2841780/145220575-b8416f22-647d-43e4-b247-9c3016e15549.png">


After:

<img width="1160" alt="Microsoft Edge screenshot 2021-12-08 q0RvvpAo" src="https://user-images.githubusercontent.com/2841780/145220589-38e930ba-96e8-442e-9a02-8c3253655eb0.png">