### PR TITLE
feat: Add yarn pnpm implementation to benchmarks

### DIFF
--- a/benchmarks/benchmarkFixture.js
+++ b/benchmarks/benchmarkFixture.js
@@ -85,6 +85,10 @@ export default async function benchmark (pm, fixture, opts) {
                 + 'nmMode: hardlinks-local\n'
                 + 'compressionLevel: 0\n'
         break
+      case 'yarn_pnpm':
+        yarnRc += 'nodeLinker: pnpm\n'
+                + 'compressionLevel: 0\n'
+        break
       case 'yarn_pnp':
         yarnRc += 'nodeLinker: pnp\n'
         break

--- a/benchmarks/commandsMap.js
+++ b/benchmarks/commandsMap.js
@@ -36,6 +36,14 @@ export default {
       'install'
     ]
   },
+  yarn_pnpm: {
+    scenario: 'yarn_pnpm',
+    legend: 'Yarn pnpm',
+    name: 'yarn',
+    args: [
+      'install'
+    ]
+  },
   yarn_pnp: {
     scenario: 'yarn_pnp',
     legend: 'Yarn PnP',

--- a/benchmarks/generateSvg.js
+++ b/benchmarks/generateSvg.js
@@ -9,12 +9,13 @@ const getHighestNumber = (array) => {
 const NPM_COLOR = '#cd3731'
 const YARN_COLOR = '#248ebd'
 const YARN_PNP_COLOR = '#40a9ff'
+const YARN_PNPM_COLOR = '#4B949B'
 const PNPM_COLOR = '#fbae00'
 
 export default (resultArrays, pms, tests, formattedNow) => {
   let svgStr = ''
   // colors taken from logos (where possible)
-  const colors = [ NPM_COLOR, PNPM_COLOR, YARN_COLOR, YARN_PNP_COLOR ]
+  const colors = [ NPM_COLOR, PNPM_COLOR, YARN_COLOR, YARN_PNPM_COLOR, YARN_PNP_COLOR ]
   // empty areas next to the graph
   const offset = {
     left: 40,
@@ -83,7 +84,7 @@ export default (resultArrays, pms, tests, formattedNow) => {
   pms.forEach((pm, index) => {
     // draw colored circle
     const radius = 4
-    const x = graph.x + radius + (radius * 4) * index
+    const x = graph.x + radius + (radius * 5) * index
     const y = vb.y + radius + 2
     svgStr += `  <circle cx="${x}" cy="${y}" r="${radius}" fill="${colors[index]}"></circle>` + '\n'
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -138,7 +138,7 @@ async function run () {
   spawn.sync('pnpm', ['add', 'yarn@latest', 'npm@latest', 'pnpm@latest'], { cwd: managersDir, stdio: 'inherit' })
   await installYarnBerryLikeModule(managersDir)
   const formattedNow = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date())
-  const pms = [ 'npm', 'pnpm', 'yarn', 'yarn_pnp' ]
+  const pms = [ 'npm', 'pnpm', 'yarn', 'yarn_pnpm', 'yarn_pnp'  ]
   const sections = []
   const svgs = []
   const opts = {
@@ -149,6 +149,7 @@ async function run () {
   for (const fixture of fixtures) {
     const npmRes = min(await benchmark(cmdsMap.npm, fixture.name, opts))
     const yarnRes = min(await benchmark(cmdsMap.yarn, fixture.name, opts))
+    const yarnPnpmRes = min(await benchmark(cmdsMap.yarn_pnpm, fixture.name, opts))
     const yarnPnPRes = min(await benchmark(cmdsMap.yarn_pnp, fixture.name, {
       ...opts,
       hasNodeModules: false,
@@ -158,23 +159,24 @@ async function run () {
       'npm': npmRes,
       'pnpm': pnpmRes,
       'yarn': yarnRes,
+      'yarn_pnpm': yarnPnpmRes,
       'yarn_pnp': yarnPnPRes,
     })
 
     sections.push(stripIndents`
       ${fixture.mdDesc}
 
-      | action  | cache | lockfile | node_modules| npm | pnpm | Yarn | Yarn PnP |
-      | ---     | ---   | ---      | ---         | --- | ---  | ---  | ---      |
-      | install |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(yarnPnPRes.firstInstall)} |
-      | install | ✔     | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | n/a |
-      | install | ✔     | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnPnPRes.withWarmCacheAndLockfile)} |
-      | install | ✔     |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(yarnPnPRes.withWarmCache)} |
-      | install |       | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(yarnPnPRes.withLockfile)} |
-      | install | ✔     |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | n/a |
-      | install |       | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | n/a |
-      | install |       |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | n/a |
-      | update  | n/a | n/a | n/a | ${prettyMs(npmRes.updatedDependencies)} | ${prettyMs(pnpmRes.updatedDependencies)} | ${prettyMs(yarnRes.updatedDependencies)} | ${prettyMs(yarnPnPRes.updatedDependencies)} |
+      | action  | cache | lockfile | node_modules| npm | pnpm | Yarn | Yarn pnpm | Yarn PnP |
+      | ---     | ---   | ---      | ---         | --- | ---  | ---  | ---       | ---      |
+      | install |       |          |             | ${prettyMs(npmRes.firstInstall)} | ${prettyMs(pnpmRes.firstInstall)} | ${prettyMs(yarnRes.firstInstall)} | ${prettyMs(yarnPnpmRes.firstInstall)} | ${prettyMs(yarnPnPRes.firstInstall)} |
+      | install | ✔     | ✔        | ✔           | ${prettyMs(npmRes.repeatInstall)} | ${prettyMs(pnpmRes.repeatInstall)} | ${prettyMs(yarnRes.repeatInstall)} | ${prettyMs(yarnPnpmRes.repeatInstall)} | n/a |
+      | install | ✔     | ✔        |             | ${prettyMs(npmRes.withWarmCacheAndLockfile)} | ${prettyMs(pnpmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnPnpmRes.withWarmCacheAndLockfile)} | ${prettyMs(yarnPnPRes.withWarmCacheAndLockfile)} |
+      | install | ✔     |          |             | ${prettyMs(npmRes.withWarmCache)} | ${prettyMs(pnpmRes.withWarmCache)} | ${prettyMs(yarnRes.withWarmCache)} | ${prettyMs(yarnPnpmRes.withWarmCache)} | ${prettyMs(yarnPnPRes.withWarmCache)} |
+      | install |       | ✔        |             | ${prettyMs(npmRes.withLockfile)} | ${prettyMs(pnpmRes.withLockfile)} | ${prettyMs(yarnRes.withLockfile)} | ${prettyMs(yarnPnpmRes.withLockfile)} | ${prettyMs(yarnPnPRes.withLockfile)} |
+      | install | ✔     |          | ✔           | ${prettyMs(npmRes.withWarmCacheAndModules)} | ${prettyMs(pnpmRes.withWarmCacheAndModules)} | ${prettyMs(yarnRes.withWarmCacheAndModules)} | ${prettyMs(yarnPnpmRes.withWarmCacheAndModules)} | n/a |
+      | install |       | ✔        | ✔           | ${prettyMs(npmRes.withWarmModulesAndLockfile)} | ${prettyMs(pnpmRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnRes.withWarmModulesAndLockfile)} | ${prettyMs(yarnPnpmRes.withWarmModulesAndLockfile)} | n/a |
+      | install |       |          | ✔           | ${prettyMs(npmRes.withWarmModules)} | ${prettyMs(pnpmRes.withWarmModules)} | ${prettyMs(yarnRes.withWarmModules)} | ${prettyMs(yarnPnpmRes.withWarmModules)} | n/a |
+      | update  | n/a | n/a | n/a | ${prettyMs(npmRes.updatedDependencies)} | ${prettyMs(pnpmRes.updatedDependencies)} | ${prettyMs(yarnRes.updatedDependencies)} | ${prettyMs(yarnPnpmRes.updatedDependencies)} | ${prettyMs(yarnPnPRes.updatedDependencies)} |
 
       ![Graph of the ${fixture.name} results](../../static/img/benchmarks/${fixture.name}.svg)
     `)
@@ -192,7 +194,7 @@ pnpm doesn't have blocking stages of installation. Each dependency has its own s
 
     svgs.push({
       path: path.join(BENCH_IMGS, `${fixture.name}.svg`),
-      file: generateSvg(resArray, [cmdsMap.npm, cmdsMap.pnpm, cmdsMap.yarn, cmdsMap.yarn_pnp], testDescriptions, formattedNow)
+      file: generateSvg(resArray, [cmdsMap.npm, cmdsMap.pnpm, cmdsMap.yarn, cmdsMap.yarn_pnpm, cmdsMap.yarn_pnp], testDescriptions, formattedNow)
     })
   }
 
@@ -201,7 +203,7 @@ pnpm doesn't have blocking stages of installation. Each dependency has its own s
 
   **Last benchmarked at**: _${formattedNow}_ (_daily_ updated).
 
-  This benchmark compares the performance of npm, pnpm, and Yarn (both regular and PnP variant).
+  This benchmark compares the performance of npm, pnpm, and Yarn (regular, pnpm and PnP variants).
   `
 
   const explanation = stripIndents`


### PR DESCRIPTION
In version 3.1 `yarn berry` added new install mode `pnpm` based on pnpm install strategy,

I added a new mode to benchmarks and made legend a bit wider since **Yarn pnpm** doesn't fit. 

I don't feel right about **Yarn pnpm** naming, if you have something better on your mind, tell me!