### PR TITLE
pnpm import - mention workspaces having to be set

### DIFF
--- a/docs/cli/import.md
+++ b/docs/cli/import.md
@@ -10,3 +10,4 @@ Added in: v2.15.0
 * `npm-shrinkwrap.json`
 * `yarn.lock` (since v6.14.0)
 
+Note that if you have workspaces you wish to import dependencies for, they will need to be declared in a [pnpm-workspace.yaml](../pnpm-workspace_yaml.md) file beforehand.


### PR DESCRIPTION
As running **pnpm import** without having declared workspaces just imports the dependencies of the root package.json