### PR TITLE
fix(npmrc): `enable-modules-dir` default is `true`

### DIFF
--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -159,7 +159,7 @@ any symlinks. It is a useful setting together with `node-linker=pnp`.
 
 Added in: v5.15.0
 
-* Default: **false**
+* Default: **true**
 * Type: **Boolean**
 
 When `false`, pnpm will not write any files to the modules directory


### PR DESCRIPTION
The default value of `enable-modules-dir` is `true`, but it's currently documented as `false`.

https://github.com/pnpm/pnpm/blob/v6.29.1/packages/config/src/index.ts#L179
https://github.com/pnpm/pnpm/pull/3051/files#diff-2eafc75a9015704b121dff9585728616f562e1625da9a53e44a86cacb94ae619R150