### PR TITLE
update uninstall.md (add reference to the PNPM_HOME)

### DIFF
--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -20,6 +20,8 @@ If you used the standalone script to install pnpm (or npx), then you should be a
 pnpm rm -g pnpm
 ```
 
+You might also want to clean the `PNPM_HOME` env variable in your shell configuration file (`$HOME/.bashrc`, `$HOME/.zshrc` or `$HOME/.config/fish/config.fish`).
+
 If you used npm to install pnpm, then you should use npm to uninstall pnpm:
 
 ```

--- a/versioned_docs/version-6.x/uninstall.md
+++ b/versioned_docs/version-6.x/uninstall.md
@@ -20,6 +20,8 @@ If you used the standalone script to install pnpm (or npx), then you should be a
 pnpm rm -g pnpm
 ```
 
+You might also want to clean the `PNPM_HOME` env variable in your shell configuration file (`$HOME/.bashrc`, `$HOME/.zshrc` or `$HOME/.config/fish/config.fish`).
+
 If you used npm to install pnpm, then you should use npm to uninstall pnpm:
 
 ```


### PR DESCRIPTION
If pnpm is installed using the `https://get.pnpm.io/install.sh` standalone script (in the "Node.js is not preinstalled" subsection), these two lines are added to the shell configuration file:
```
export PNPM_HOME="/home/username/.local/share/pnpm"
export PATH="$PNPM_HOME:$PATH"
```