### PR TITLE
Update gitlab example

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -118,7 +118,9 @@ build:
   script:
     - pnpm install # install dependencies
   cache:
-    key: "$CI_COMMIT_REF_SLUG"
+    key:
+      files:
+        - pnpm-lock.yaml
     paths:
       - .pnpm-store
 ```


### PR DESCRIPTION
Updates gitlab example to cache based on lock files content for far more robust and reused caches.