### PR TITLE
docs: correct nesting level for .modules.yaml

### DIFF
--- a/blog/2020-05-27-flat-node-modules-is-not-the-only-way.md
+++ b/blog/2020-05-27-flat-node-modules-is-not-the-only-way.md
@@ -60,7 +60,7 @@ Let's see what is inside `express`:
       LICENSE
       package.json
       Readme.md
-    .modules.yaml
+  .modules.yaml
 ```
 
 `express` has no `node_modules`? Where are all the dependencies of `express`?


### PR DESCRIPTION
`.modules.yaml` file is located in `node_modules` folder not in `exrpress`.