### PR TITLE
Avoid looking for packages at infinite depth.

### DIFF
--- a/docs/pnpm-workspace_yaml.md
+++ b/docs/pnpm-workspace_yaml.md
@@ -12,8 +12,8 @@ For example:
 ```yaml title="pnpm-workspace.yaml"
 packages:
   # all packages in subdirs of packages/ and components/
-  - 'packages/**'
-  - 'components/**'
+  - 'packages/*'
+  - 'components/*'
   # exclude packages that are inside test directories
   - '!**/test/**'
 ```

--- a/docs/pnpm-workspace_yaml.md
+++ b/docs/pnpm-workspace_yaml.md
@@ -11,9 +11,10 @@ For example:
 
 ```yaml title="pnpm-workspace.yaml"
 packages:
-  # all packages in subdirs of packages/ and components/
+  # all packages in direct subdirs of packages/
   - 'packages/*'
-  - 'components/*'
+  # all packages in subdirs of components/
+  - 'components/**'
   # exclude packages that are inside test directories
   - '!**/test/**'
 ```


### PR DESCRIPTION
As well-illustrated here, the documentation of `packages/**` will result in checking at arbitrary depths for `package.json` files in a misguided attempt to find workspaces. This isn't the way most humans would construct project layouts and is a performance footgun: https://github.com/vercel/turborepo/issues/667#issuecomment-1128057910