### PR TITLE
Fix example of patchedDependencies docs

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -428,7 +428,9 @@ Example:
 ```json
 {
   "pnpm": {
-    "express@4.18.1": "patches/express@4.18.1.patch"
+    "patchedDependencies": {
+      "express@4.18.1": "patches/express@4.18.1.patch"
+    }
   }
 }
 ```


### PR DESCRIPTION
`patchedDependencies` was missing under `pnpm`.