### PR TITLE
Update overrides documentation

### DIFF
--- a/docs/package_json.md
+++ b/docs/package_json.md
@@ -205,8 +205,6 @@ This field allows you to instruct pnpm to override any dependency in the
 dependency graph. This is useful to enforce all your packages to use a single
 version of a dependency, backport a fix, or replace a dependency with a fork.
 
-Note that the overrides field can only be set at the root of the project.
-
 An example of the `"pnpm"."overrides"` field:
 
 ```json


### PR DESCRIPTION
It seems like the statement:

> "Note that the overrides field can only be set at the root of the project."

May, not be a true statement.

After discovering a version conflict in our deployments, we applied the overrides to two packages within our monorepo. This change resolved the version conflict.

I'm sure this statement is here with reason. Do we know why this line is here and why overrides only apply (perhaps a better choice of words is "should") in the root package.json?