### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/completion.md
+++ b/docs/completion.md
@@ -23,12 +23,12 @@ To see examples of completion, read [this article].
 
 [this article]: https://medium.com/pnpm/pnpm-v4-9-comes-with-command-completion-a411715260b4
 
-### Fig
+## Fig (on macOS only)
 
-You can get IDE-style autocompletions for pnpm with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+You can get IDE-style autocompletions for pnpm with [Fig](https://fig.io/). It works in Bash, Zsh, and Fish.
 
 To install, run:
 
-```shell
+```text
 brew install fig
 ```

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -25,10 +25,12 @@ To see examples of completion, read [this article].
 
 ## Fig (on macOS only)
 
-You can get IDE-style autocompletions for pnpm with [Fig](https://fig.io/). It works in Bash, Zsh, and Fish.
+You can get IDE-style autocompletions for pnpm with [Fig]. It works in Bash, Zsh, and Fish.
 
 To install, run:
 
 ```text
 brew install fig
 ```
+
+[Fig]: https://fig.io/

--- a/docs/completion.md
+++ b/docs/completion.md
@@ -22,3 +22,13 @@ pnpm install-completion zsh
 To see examples of completion, read [this article].
 
 [this article]: https://medium.com/pnpm/pnpm-v4-9-comes-with-command-completion-a411715260b4
+
+### Fig
+
+You can get IDE-style autocompletions for pnpm with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including pnpm. It looks like this:

<img width="384" alt="image" src="https://user-images.githubusercontent.com/4949076/181389113-cf8ac68f-e1ce-442d-813c-f0ac73598f48.png">

We think this will help users become more efficient with pnpm CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!