### PR TITLE
Carbonads text fixed when dark mode enables

### DIFF
--- a/src/css/customTheme.css
+++ b/src/css/customTheme.css
@@ -48,11 +48,11 @@ html[data-theme="dark"] .header-github-link::before {
 
 #carbonads a {
   text-decoration: none;
-  color: inherit;
+  color: #000000;
 }
 
 #carbonads a:hover {
-  color: inherit;
+  color: #475569;
 }
 
 #carbonads span {
@@ -84,6 +84,7 @@ html[data-theme="dark"] .header-github-link::before {
   font-size: 13px;
   line-height: 1.5;
   text-align: left;
+  color: #000000;
 }
 
 #carbonads .carbon-poweredby {


### PR DESCRIPTION
Carbonads text is not seeing properly when we enable the dark mode. I fixed some css styles to properly visible in both light+dark modes.