### PR TITLE
fix(release): specify node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 public-hoist-pattern[]=@mdx-js/react
 public-hoist-pattern[]=url-loader
+use-node-version=18.6.0


### PR DESCRIPTION
Fixes [release failures](https://github.com/pnpm/pnpm.github.io/runs/7881960299?check_suite_focus=true) in main:
```
Error:  Minimum Node.js version not met :(
[INFO] You are using Node.js v14.20.0, Requirement: Node.js >=16.14.
```

Error started after: https://github.com/pnpm/pnpm.github.io/commit/87da9c679895c9bd3c7b232ad40300fc3d6f61ef - this reverts the change to get releases moving again. 