### PR TITLE
docs github actions versions

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -81,7 +81,7 @@ jobs:
       matrix:
         node-version: [15]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v2.2.2
       with:
         version: 7

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -86,7 +86,7 @@ jobs:
       with:
         version: 7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -82,7 +82,7 @@ jobs:
         node-version: [15]
     steps:
     - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v2.2.2
+    - uses: pnpm/action-setup@v2.2.4
       with:
         version: 7
     - name: Use Node.js ${{ matrix.node-version }}

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -73,7 +73,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: install pnpm

--- a/docs/using-changesets.md
+++ b/docs/using-changesets.md
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: setup node.js

--- a/versioned_docs/version-6.x/continuous-integration.md
+++ b/versioned_docs/version-6.x/continuous-integration.md
@@ -86,7 +86,7 @@ jobs:
       with:
         version: 6.20.3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'

--- a/versioned_docs/version-6.x/continuous-integration.md
+++ b/versioned_docs/version-6.x/continuous-integration.md
@@ -81,7 +81,7 @@ jobs:
       matrix:
         node-version: [15]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v2.0.1
       with:
         version: 6.20.3

--- a/versioned_docs/version-6.x/using-changesets.md
+++ b/versioned_docs/version-6.x/using-changesets.md
@@ -73,7 +73,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: setup node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: install pnpm

--- a/versioned_docs/version-6.x/using-changesets.md
+++ b/versioned_docs/version-6.x/using-changesets.md
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: setup node.js


### PR DESCRIPTION
[actions/checkout](https://github.com/actions/checkout) is on `v3`.

[actions/setup-node](https://github.com/actions/setup-node) is on `v3`.

