### PR TITLE
docs: alpine wget instead of curl

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ wget -qO- https://get.pnpm.io/install.sh | sh -
 ### On Alpine Linux
 
 ```sh
-curl -fsSL "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" -o /bin/pnpm; chmod +x /bin/pnpm;
+wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
 ```
 
 ### Prerequisites


### PR DESCRIPTION
`wget` is included in vanilla alpine (`docker run alpine`)