### PR TITLE
fixing the year in the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -251,7 +251,7 @@ module.exports={
           ],
         },
       ],
-      "copyright": "Copyright © 2015-2022 contributors of pnpm",
+      "copyright": `Copyright © 2015-${new Date().getFullYear()} contributors of pnpm`,
       "logo": {
         "src": "img/pnpm-light.svg"
       },


### PR DESCRIPTION
Fixed incorrect display of the year in сopyright in the footer. Now the year is automatically calculated