### PR TITLE
fix(benchmarks): update benchmark interval label

### DIFF
--- a/src/pages/benchmarks.md
+++ b/src/pages/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks of JavaScript Package Managers
 
-**Last benchmarked at**: _Jan 8, 2023, 3:15 AM_ (_daily_ updated).
+**Last benchmarked at**: _Jan 8, 2023, 3:15 AM_ (_weekly_ updated).
 
 This benchmark compares the performance of npm, pnpm, Yarn Classic, and Yarn PnP (check [Yarn's benchmarks](https://yarnpkg.com/benchmarks) for any other Yarn modes that are not included here).
 


### PR DESCRIPTION
https://pnpm.io/benchmarks

![image](https://user-images.githubusercontent.com/298435/212918453-a4d1de29-03bb-4c84-a449-bd8423b806c2.png)

> says daily, was days ago

https://github.com/pnpm/pnpm.github.io/commit/3c03b982d1b44d5df37a4c6cda14e6675d4f896f indicates the benchmark interval changed from daily to [weekly](https://github.com/pnpm/pnpm.github.io/actions/workflows/benchmark.yml)

> not sure about that end of file diff with the image, I didn't touch that part and edited through their GUI. perhaps it's an artifact of the github action not giving it a EOF character?