### PR TITLE
make it clearer that pnpx doesn't run a binary of a project's dependency

### DIFF
--- a/versioned_docs/version-6.x/pnpx-cli.md
+++ b/versioned_docs/version-6.x/pnpx-cli.md
@@ -31,8 +31,9 @@ If you just want to run a binary of a project's dependency, see [`pnpm exec`].
 ## For npm users
 
 npm has a great package runner called [npx]. pnpm offers the same tool via the
-`pnpx` command. The only difference is that `pnpx` uses `pnpm` for installing
-packages.
+`pnpx` command. The only difference is that `pnpx` uses `pnpm` for installing packages. 
+However, it's important to note that unlike `npx`, `pnpx` does not run binaries of project 
+dependencies, you should use the [`pnpm exec`] command instead.
 
 [npx]: https://www.npmjs.com/package/npx
 [`pnpm exec`]: ./cli/exec.md


### PR DESCRIPTION
I think it's important to note that pnpx and npx are not completely equivalent, as npx runs the binary of a project's dependency, while pnpx doesn't. This distinction can cause confusion for npm users who may assume that pnpx can be used interchangeably with npx when running binary commands of project dependencies. One specific example of this discrepancy is when the binary command name is different from the package name, as seen in this issue (https://github.com/sverweij/dependency-cruiser/issues/725). To avoid confusion, it's helpful to understand the differences between pnpx and npx when it comes to running binary commands of project dependencies.