### PR TITLE
docs(cli): remove unnecessary escape

### DIFF
--- a/docs/cli/install.md
+++ b/docs/cli/install.md
@@ -30,7 +30,7 @@ setting to `false`.
 
 ### --force
 
-Force reinstall dependencies: refetch packages modified in store, recreate a lockfile and/or modules directory created by a non-compatible version of pnpm. Install all optionalDependencies even they don\'t satisfy the current environment(cpu, os, arch).
+Force reinstall dependencies: refetch packages modified in store, recreate a lockfile and/or modules directory created by a non-compatible version of pnpm. Install all optionalDependencies even they don't satisfy the current environment(cpu, os, arch).
 
 ### --offline
 


### PR DESCRIPTION
removed unnecessary single quote escape, in the docs this is rendered with `\`

https://pnpm.io/cli/install#--force