### PR TITLE
docs: fix pnpm version in corepack prepare step

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -17,7 +17,7 @@ cache:
     - "~/.pnpm-store"
 before_install:
   - corepack enable
-  - corepack prepare pnpm@latest-7 --activate
+  - corepack prepare pnpm@latest --activate
   - pnpm config set store-dir ~/.pnpm-store
 install:
   - pnpm install
@@ -44,7 +44,7 @@ blocks:
         - name: pnpm install
           commands:
             - corepack enable
-            - corepack prepare pnpm@latest-7 --activate
+            - corepack prepare pnpm@latest --activate
             - checkout
             - cache restore node-$(checksum pnpm-lock.yaml)
             - pnpm install
@@ -62,7 +62,7 @@ to your `appveyor.yml`:
 install:
   - ps: Install-Product node $env:nodejs_version
   - corepack enable
-  - corepack prepare pnpm@latest-7 --activate
+  - corepack prepare pnpm@latest --activate
   - pnpm install
 ```
 
@@ -117,7 +117,7 @@ build:
   image: node:14.16.0-buster
   before_script:
     - corepack enable
-    - corepack prepare pnpm@latest-7 --activate
+    - corepack prepare pnpm@latest --activate
     - pnpm config set store-dir .pnpm-store
   script:
     - pnpm install # install dependencies
@@ -146,7 +146,7 @@ pipelines:
           image: node:14.16.0
           script:
             - corepack enable
-            - corepack prepare pnpm@latest-7 --activate
+            - corepack prepare pnpm@latest --activate
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
           caches:
@@ -170,7 +170,7 @@ steps:
 
   - script: |
       corepack enable
-      corepack prepare pnpm@latest-7 --activate
+      corepack prepare pnpm@latest --activate
       pnpm config set store-dir $(pnpm_config_cache)
     displayName: "Setup pnpm"
 
@@ -205,7 +205,7 @@ jobs:
           name: Install pnpm package manager
           command: |
             corepack enable
-            corepack prepare pnpm@latest-7 --activate
+            corepack prepare pnpm@latest --activate
       - run:
           name: Install Dependencies
           command: |
@@ -233,7 +233,7 @@ pipeline {
         stage('Build') { 
             steps {
                 sh 'corepack enable'
-                sh 'corepack prepare pnpm@latest-7 --activate'
+                sh 'corepack prepare pnpm@latest --activate'
                 sh 'pnpm install'
             }
         }


### PR DESCRIPTION
When I followed the docs, I got the following error:

```
Usage Error: Tag not found (latest-7)
```
Shouldn't it be either `pnpm@latest` or `pnpm@7`?

![Screenshot 2023-02-21 at 16 19 04](https://user-images.githubusercontent.com/58401630/220402372-8087f2a9-c776-4a8d-a498-5db6ba57952e.png)


