### PR TITLE
add usage of PNPM_HOME env variable for store-dir

### DIFF
--- a/docs/npmrc.md
+++ b/docs/npmrc.md
@@ -105,6 +105,7 @@ root of `node_modules`, you can set this to `true` to hoist them for you.
 ### store-dir
 
 * Default:
+  * If the **$PNPM_HOME** env variable is set, then **$PNPM_HOME/store**
   * If the **$XDG_DATA_HOME** env variable is set, then **$XDG_DATA_HOME/pnpm/store**
   * On Windows: **~/AppData/Local/pnpm/store**
   * On macOS: **~/Library/pnpm/store**


### PR DESCRIPTION
Priority usage of `process.env.PNPM_HOME` for the store-dir was added Oct 29, 2022 in https://github.com/pnpm/pnpm/pull/5566.

This documentation change reflects that addition and how it's usage is slightly different from `process.env.XDG_DATA_HOME`.