### PR TITLE
Explain "list" depth default and how to list all

### DIFF
--- a/docs/cli/list.md
+++ b/docs/cli/list.md
@@ -39,9 +39,10 @@ List packages in the global install directory instead of in the current project.
 
 Max display depth of the dependency tree.
 
-`pnpm ls --depth 0` will list direct dependencies only.
+`pnpm ls --depth 0` (default) will list direct dependencies only.
 `pnpm ls --depth -1` will list projects only. Useful inside a workspace when
 used with the `-r` option.
+`pnpm ls --depth Infinity` will list all dependencies regardless of depth.
 
 ### --prod, -P
 


### PR DESCRIPTION
I was confused why `pnpm list` was not returning results, until I found https://github.com/pnpm/pnpm/issues/1932, explaining the default for `--depth` and how to get all depths.  This adds that information to the docs to help others.