### PR TITLE
docs(installation): add choco method

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,14 @@ If you have Scoop installed, you can install pnpm using the following command:
 scoop install nodejs-lts pnpm
 ```
 
+## Using Choco
+
+If you have Chocolatey installed, you can install pnpm using the following command:
+
+```
+choco install pnpm
+```
+
 :::tip
 
 Do you wanna use pnpm on CI servers? See: [Continuous Integration](./continuous-integration.md).


### PR DESCRIPTION
## Context

Starting today, pnpm is available on Chocolatey as well.

Like Scoop, Chocolatey is a package manager for Windows. Personally I only use Choco and not Scoop.

Choco pnpm installation page: https://community.chocolatey.org/packages/pnpm
Source of the choco package (installation script): https://github.com/MKMZ/ChocolateyPackages/tree/main/pnpm

## Changes

- Add choco as a documented way to install pnpm.