### PR TITLE
docs: Update gitlab and bitbucket CI docs, friendly for developers

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -120,10 +120,10 @@ stages:
 
 build:
   stage: build
-  image: node:16.9.0
+  image: node:16.20.0
   before_script:
     - corepack enable
-    - corepack prepare pnpm@latest-8 --activate
+    - corepack prepare pnpm@8.5.1 --activate
     - pnpm config set store-dir .pnpm-store
   script:
     - pnpm install # install dependencies
@@ -149,10 +149,10 @@ pipelines:
     "**":
       - step:
           name: Build and test
-          image: node:16.9.0
+          image: node:16.20.0
           script:
             - corepack enable
-            - corepack prepare pnpm@latest-8 --activate
+            - corepack prepare pnpm@8.5.1 --activate
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
           caches:

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -123,7 +123,7 @@ build:
   image: node:16.20.0
   before_script:
     - corepack enable
-    - corepack prepare pnpm@8.5.1 --activate
+    - corepack prepare pnpm@latest-8 --activate
     - pnpm config set store-dir .pnpm-store
   script:
     - pnpm install # install dependencies
@@ -152,7 +152,7 @@ pipelines:
           image: node:16.20.0
           script:
             - corepack enable
-            - corepack prepare pnpm@8.5.1 --activate
+            - corepack prepare pnpm@latest-8 --activate
             - pnpm install
             - pnpm run build # Replace with your build/test…etc. commands
           caches:


### PR DESCRIPTION
### Description

Currently the online CI example cannot work, it has two errors,
1. The Node.js must >= 16.14
2. Corepack can not use  `@latest-8 syntax`

So I updated docs, at least it can work, it will friendly for developers

![image](https://github.com/pnpm/pnpm.github.io/assets/25958590/3f8638f0-2e53-4e11-a672-5ac7f8cead28)
