### PR TITLE
fix: show patch dependencies category

### DIFF
--- a/docs/cli/patch-remove.md
+++ b/docs/cli/patch-remove.md
@@ -3,4 +3,10 @@ id: patch-remove
 title: "pnpm patch-remove <pkg...>"
 ---
 
-Remove existing patch files.
+Added in: v8.5.0
+
+Remove existing patch files and settings in `pnpm.patchedDependencies`.
+
+```sh
+pnpm patch-remove foo@1.0.0 bar@1.0.1
+```

--- a/sidebars.json
+++ b/sidebars.json
@@ -34,7 +34,8 @@
         "label": "Patch dependencies",
         "items": [
           "cli/patch",
-          "cli/patch-commit"
+          "cli/patch-commit",
+          "cli/patch-remove"
         ]
       },
       {

--- a/versioned_sidebars/version-8.x-sidebars.json
+++ b/versioned_sidebars/version-8.x-sidebars.json
@@ -98,6 +98,17 @@
             },
             {
               "type": "doc",
+              "id": "version-8.x/cli/dedupe"
+            }
+          ]
+        },
+        {
+          "collapsed": true,
+          "type": "category",
+          "label": "Patch dependencies",
+          "items": [
+            {
+              "type": "doc",
               "id": "version-8.x/cli/patch"
             },
             {
@@ -106,7 +117,7 @@
             },
             {
               "type": "doc",
-              "id": "version-8.x/cli/dedupe"
+              "id": "version-8.x/cli/patch-remove"
             }
           ]
         },


### PR DESCRIPTION
show "Patch Depedenencies" category in  "CLI Commands":
![image](https://github.com/pnpm/pnpm.github.io/assets/41503212/a171e03c-c63f-4125-bee4-a65c4c871025)
